### PR TITLE
feat: add uninstall.ipynb backed by install manifest (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Before running `install.ipynb`, ensure the person running it has:
 #### Installation Options
 
 - **Full Installation** (`install.ipynb`): Complete setup including dashboard, app, Genie Space, and reload job
+- **Uninstall** (`uninstall.ipynb`): Tear down everything an install deployed; reads the state manifest written at install time.
 
 #### Telemetry
 

--- a/install.ipynb
+++ b/install.ipynb
@@ -176,7 +176,8 @@
     "\n",
     "# Create catalog if it does not exist\n",
     "existing_catalogs = [r[0] for r in spark.sql(\"SHOW CATALOGS\").collect()]\n",
-    "if CATALOG not in existing_catalogs:\n",
+    "catalog_created_by_install = CATALOG not in existing_catalogs\n",
+    "if catalog_created_by_install:\n",
     "    print(f\"   \\u26a0\\ufe0f  Catalog '{CATALOG}' not found  creating it...\")\n",
     "    spark.sql(f\"CREATE CATALOG IF NOT EXISTS `{CATALOG}`\")\n",
     "    print(f\"   \\u2705 Catalog '{CATALOG}' created.\")\n",
@@ -1660,7 +1661,20 @@
     "        else:\n",
     "            print(f\"  Genie SP permission: {gp_resp.status_code}  {gp_resp.text[:200]}\")\n",
     "    except Exception as _e:\n",
-    "        print(f\"  Genie SP permission error: {_e}\")\n"
+    "        print(f\"  Genie SP permission error: {_e}\")\n",
+    "\n",
+    "\n",
+    "# \u2500\u2500 Write install manifest for uninstall.ipynb \u2500\u2500\n",
+    "spark.createDataFrame(\n",
+    "    [(timestamp, datetime.utcnow(), CATALOG, catalog_created_by_install,\n",
+    "      workspace_path, app_name, sp_app_id, job_id, warehouse_id,\n",
+    "      dashboard_id, genie_space_id or \"\")],\n",
+    "    schema=(\"install_id STRING, created_at TIMESTAMP, catalog STRING, \"\n",
+    "            \"catalog_created_by_install BOOLEAN, workspace_path STRING, \"\n",
+    "            \"app_name STRING, sp_app_id STRING, job_id BIGINT, \"\n",
+    "            \"warehouse_id STRING, dashboard_id STRING, genie_space_id STRING\")\n",
+    ").write.format(\"delta\").mode(\"append\").saveAsTable(f\"{CATALOG}.waf_cache._install_manifest\")\n",
+    "print(f\" Install manifest written: {CATALOG}.waf_cache._install_manifest (install_id={timestamp})\")\n"
    ]
   }
  ],

--- a/uninstall.ipynb
+++ b/uninstall.ipynb
@@ -1,0 +1,124 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# WAF Assessment Tool \u2014 Uninstall\n",
+    "\n",
+    "Tears down everything `install.ipynb` deployed, by reading the install manifest written at install time.\n",
+    "\n",
+    "**What this removes:** Genie space, Lakeview dashboard, Databricks App, reload job, app workspace files, `waf_cache` schema (CASCADE), and the catalog if install created it.\n",
+    "\n",
+    "**Requires:** install was performed by a version of `install.ipynb` that writes `_install_manifest`. For older installs, delete resources manually.\n",
+    "\n",
+    "**Failure model:** this script fails loudly. If a resource is already gone, comment out that line and re-run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# STEP 1: CONFIGURATION\n",
+    "catalog    = \"<<your_catalog>>\"   # the catalog used during install\n",
+    "install_id = None                  # None = uninstall the most recent install; else set the install_id string\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# STEP 2: LOAD MANIFEST ROW\n",
+    "import requests\n",
+    "\n",
+    "ctx     = dbutils.notebook.entry_point.getDbutils().notebook().getContext()\n",
+    "api_url = ctx.apiUrl().get()\n",
+    "token   = ctx.apiToken().get()\n",
+    "\n",
+    "where = \"\" if install_id is None else f\"WHERE install_id = '{install_id}'\"\n",
+    "row = spark.sql(\n",
+    "    f\"SELECT * FROM `{catalog}`.`waf_cache`.`_install_manifest` {where} \"\n",
+    "    f\"ORDER BY created_at DESC LIMIT 1\"\n",
+    ").collect()[0]\n",
+    "\n",
+    "print(f\"Uninstalling install_id={row.install_id} (created {row.created_at})\")\n",
+    "for f in [\"catalog\", \"catalog_created_by_install\", \"workspace_path\", \"app_name\",\n",
+    "          \"job_id\", \"dashboard_id\", \"genie_space_id\"]:\n",
+    "    print(f\"  {f:30s}: {row[f]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# STEP 3: DELETE API-BACKED RESOURCES\n",
+    "headers = {\"Authorization\": f\"Bearer {token}\"}\n",
+    "\n",
+    "if row.genie_space_id:\n",
+    "    print(\" Deleting Genie space...\")\n",
+    "    requests.delete(f\"{api_url}/api/2.0/genie/spaces/{row.genie_space_id}\", headers=headers).raise_for_status()\n",
+    "\n",
+    "print(\" Deleting Lakeview dashboard...\")\n",
+    "requests.delete(f\"{api_url}/api/2.0/lakeview/dashboards/{row.dashboard_id}\", headers=headers).raise_for_status()\n",
+    "\n",
+    "print(\" Deleting Databricks App...\")\n",
+    "requests.delete(f\"{api_url}/api/2.0/apps/{row.app_name}\", headers=headers).raise_for_status()\n",
+    "\n",
+    "print(\" Deleting reload job...\")\n",
+    "requests.post(\n",
+    "    f\"{api_url}/api/2.1/jobs/delete\",\n",
+    "    headers={**headers, \"Content-Type\": \"application/json\"},\n",
+    "    json={\"job_id\": row.job_id},\n",
+    ").raise_for_status()\n",
+    "\n",
+    "print(\" Deleting app workspace path...\")\n",
+    "requests.post(\n",
+    "    f\"{api_url}/api/2.0/workspace/delete\",\n",
+    "    headers={**headers, \"Content-Type\": \"application/json\"},\n",
+    "    json={\"path\": row.workspace_path, \"recursive\": True},\n",
+    ").raise_for_status()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# STEP 4: DROP UC OBJECTS\n",
+    "print(f\" Dropping schema {row.catalog}.waf_cache (CASCADE)...\")\n",
+    "spark.sql(f\"DROP SCHEMA `{row.catalog}`.`waf_cache` CASCADE\")\n",
+    "\n",
+    "if row.catalog_created_by_install:\n",
+    "    print(f\" Dropping catalog {row.catalog} (created by install)...\")\n",
+    "    spark.sql(f\"DROP CATALOG `{row.catalog}`\")\n",
+    "else:\n",
+    "    print(f\" Catalog {row.catalog} pre-existed \u2192 kept.\")\n",
+    "\n",
+    "print(\"\\n Uninstall complete.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "notebookName": "uninstall",
+   "language": "python"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

New `uninstall.ipynb` that tears down every resource `install.ipynb` deploys, by reading a state manifest written at install time - **therefore won't work for installs run on previous versions of this repo.**
Closes #9.

## Resources tracked

| Resource | Deletion |
|---|---|
| Databricks App | deleted |
| App service principal | deleted (cascade from app deletion) |
| Reload job | deleted |
| Workspace path (recursive) | deleted |
| `waf_cache` schema (CASCADE) | deleted |
| Catalog | deleted if `catalog_created_by_install=true`, else kept |
| Lakeview dashboard | trashed |
| Genie space | trashed |

Trashed resources are auto-purged after **30 days** (Databricks default trash retention). Lakeview and Genie REST APIs expose no permanent-purge endpoint.

## Design

- Manifest at `{catalog}.waf_cache._install_manifest` written at end of install (Step 7) and read by uninstall — chosen over naming-convention scanning. If the manifest write fails during install, uninstall has nothing to read.

## Test plan (verified end-to-end on AWS workspace)

- [x] `install.ipynb` runs to completion → `_install_manifest` contains one row with all fields populated, including `genie_space_id`.
- [x] `uninstall.ipynb` runs to completion → app, app SP, reload job, workspace path, `waf_cache` schema all permanently removed.
- [x] Pre-existing catalog (`catalog_created_by_install=false`) → catalog preserved post-uninstall.